### PR TITLE
Only resolve cache/session to memcache if the driver is memcache

### DIFF
--- a/src/Igormatkovic/Memcache/MemcacheServiceProvider.php
+++ b/src/Igormatkovic/Memcache/MemcacheServiceProvider.php
@@ -8,11 +8,11 @@ use Illuminate\Cache\CacheManager;
 class MemcacheServiceProvider extends ServiceProvider {
 
     /**
-   	 * Indicates if loading of the provider is deferred.
+        * Indicates if loading of the provider is deferred.
      *
      * @var bool
      */
-	protected $defer = false;
+    protected $defer = false;
 
     /**
      * Register the service provider.
@@ -21,31 +21,39 @@ class MemcacheServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-     	$servers = $this->app['config']['cache.memcached'];
+        $isCacheDriver = $this->app['config']['cache.driver'] == 'memcache';
+        $servers = $this->app['config']['cache.memcached'];
         $prefix = $this->app['config']['cache.prefix'];
+        $isSessionDriver = $this->app['config']['session.driver'] == 'memcache';
         $minutes = $this->app['config']['session.lifetime'];
+        $memcache = $repo = $handler = $manager = $driver = null;
 
-        $memcache = new MemcacheConnector();
-        $memcache = $memcache->connect($servers);
-        $repo = new Repository(new MemcacheStore($memcache, $prefix));
-        $handler = new MemcacheHandler($repo, $minutes);
+        if($isCacheDriver) {
+            $memcache = new MemcacheConnector();
+            $memcache = $memcache->connect($servers);
+            $repo = new Repository(new MemcacheStore($memcache, $prefix));
 
-        $this->app->resolving('cache', function($cache) use ($repo)
-        {
-            $cache->extend('memcache', function($app) use ($repo)
+            $this->app->resolving('cache', function($cache) use ($repo)
             {
-             	return $repo;
+                $cache->extend('memcache', function($app) use ($repo)
+                {
+                     return $repo;
+                });
             });
-        });
 
-        $this->app->resolving('session', function($session) use ($handler)
-    	{
-            $session->extend('memcache', function($app) use ($handler)
-            {
+            if($isSessionDriver) {
+                $handler = new MemcacheHandler($repo, $minutes);
                 $manager = new MemcacheSessionManager($handler);
+                $driver = $manager->driver('memcache');
 
-                return $manager->driver('memcache');
-            });
-        });
+                $this->app->resolving('session', function($session) use ($driver)
+                {
+                    $session->extend('memcache', function($app) use ($driver)
+                    {
+                        return $driver;
+                    });
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
Only resolve cache/session to memcache if the driver is memcache.  Another developer found that it was trying to connect to memcache with the connector even when the drivers were not specified to use memcache.  This will fix that issue.
